### PR TITLE
Support highlighting deletions; add "vhl/define-extension" macro

### DIFF
--- a/volatile-highlights.el
+++ b/volatile-highlights.el
@@ -133,6 +133,8 @@
   (require 'easy-mmode)
   (require 'advice))
 
+(provide 'volatile-highlights)
+
 
 ;;;============================================================================
 ;;;
@@ -787,5 +789,4 @@ extensions."
 
 (vhl/install-extension 'nonincremental-search)
 
-(provide 'volatile-highlights)
 ;;; volatile-highlights.el ends here


### PR DESCRIPTION
This pull request adds support for highlighting the position from which text was deleted, and it adds a macro `vhl/define-extension` that makes it easy to define simple extensions (i.e. extensions that don't need to do anything conditionally or require features). This macro is used to define an extension for highlighting the positions of killed text, and it is also used to simplify the "undo" and "yank" extensions to one line each.
