### PR TITLE
Add Vhl/highlight-reversed

### DIFF
--- a/volatile-highlights.el
+++ b/volatile-highlights.el
@@ -234,6 +234,11 @@ where the deleted text used to be would be highlighted."
   :type 'boolean
   :group 'volatile-highlights)
 
+(defcustom Vhl/highlight-reversed nil
+  "If t, highlight the area sorrounding the region."
+  :type 'boolean
+  :group 'volatile-highlights)
+
 
 ;;;============================================================================
 ;;;
@@ -244,22 +249,30 @@ where the deleted text used to be would be highlighted."
 ;;-----------------------------------------------------------------------------
 ;; (vhl/add-range BEG END &OPTIONAL BUF FACE) => VOID
 ;;-----------------------------------------------------------------------------
-(defun vhl/add-range (beg end &optional buf face)
+(defun vhl/add-range (beg end &optional buf face reverse)
   "Add a volatile highlight to the buffer `BUF' at the position
 specified by `BEG' and `END' using the face `FACE'.
 
 When the buffer `BUF' is not specified or its value is `nil',
 volatile highlight will be added to current buffer.
 
-When the face `FACE' is not specified or its value is `nil',
-the default face `vhl/default-face' will
-be used as the value."
+When the face `FACE' is not specified or its value is `nil', the
+default face `vhl/default-face' will be used as the value.
+
+If `REVERSE' is `t', the highlight is placed on the sorrounding
+region instead. `Vhl/highlight-reversed' inverts the highlight
+globally."
   (let* ((face (or face 'vhl/default-face))
-		 (hl (vhl/.make-hl beg end buf face)))
-	(setq vhl/.hl-lst
-		  (cons hl vhl/.hl-lst))
-	(add-hook 'pre-command-hook 'vhl/clear-all)))
-(define-obsolete-function-alias 'vhl/add 'vhl/add-range "1.5")
+	 (rev (if Vhl/highlight-reversed (not reverse) reverse)))
+    (setq vhl/.hl-lst
+	  (if rev
+	      (append
+	       (list (vhl/.make-hl (point-min) beg buf face)
+		     (vhl/.make-hl end (point-max) buf face))
+	       vhl/.hl-lst)
+	      (cons (vhl/.make-hl beg end buf face) vhl/.hl-lst)))
+    (add-hook 'pre-command-hook 'vhl/clear-all)))
+(define-obsolete-function-alias 'vhl/add 'vhl/add-rang "1.5")
 
 ;;-----------------------------------------------------------------------------
 ;; (vhl/add-position POS &OPTIONAL BUF FACE) => VOID


### PR DESCRIPTION
So here's some fun about issue #8.

I add a 'reverse' parameter to vhl/add-range that marks the two regions around the selection. In addition to that, I added a general 'Vhl/highlight-reversed' variable to define the general behavior of vhl/add-range, which simply flips the value of 'reverse'.

How does it look like?

This is how it normally looks after yanking a block of text:

![highlight-normal](https://cloud.githubusercontent.com/assets/1017726/8579889/8b4579ba-25b7-11e5-807b-f5ac1e80b272.png)

and this is afterwards:

![highlight-reversed](https://cloud.githubusercontent.com/assets/1017726/8579902/a455b1ea-25b7-11e5-9391-1778d7933cba.png)

I've chosed "#999" here for the highlight background (yes, it's normally lighter).

I have mixed feelings... it's very nice if the region is large (>1 line), but it sucks for small yanks.
It's also incomplete: vhl/add-range should poke holes in the overlays when vhl/add-range is called repeatedly with an inverted region.

It's a funny test anyway.
Comments?