### PR TITLE
Add autoload cookie

### DIFF
--- a/volatile-highlights.el
+++ b/volatile-highlights.el
@@ -216,6 +216,7 @@
 ;;;  Minor Mode Definition.
 ;;;
 ;;;============================================================================
+;;;###autoload
 (easy-mmode-define-minor-mode
  volatile-highlights-mode "Minor mode for visual feedback on some operations."
  :global t


### PR DESCRIPTION
http://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html

定義の直前にautoload cookieを付けることで、パッケージマネージャーを利用した環境では明示的にrequireせずとも`volatile-highlights-mode`を利用することができるようになります。
