### PR TITLE
Replace cl with cl-lib for emacs 27

### DIFF
--- a/volatile-highlights.el
+++ b/volatile-highlights.el
@@ -195,7 +195,7 @@
 (defconst vhl/version "1.8")
 
 (eval-when-compile
-  (require 'cl)
+  (require 'cl-lib)
   (require 'easy-mmode)
   (require 'advice))
 


### PR DESCRIPTION
Package cl is deprecated.