### PR TITLE
Do not require etags

### DIFF
--- a/volatile-highlights.el
+++ b/volatile-highlights.el
@@ -650,7 +650,6 @@ extensions."
   (defun vhl/ext/etags/on ()
   "Turn on volatile highlighting for `etags'."
   (interactive)
-  (require 'etags)
   (advice-add 'find-tag :after #'vhl/ext/etags/.after-find-tag))
 
 (defun vhl/ext/etags/off ()


### PR DESCRIPTION
This is not necessary for the advice mechanism to work, and causes
unnecessary loading of etags and its dependencies at startup if
volatile-highlights-mode is enabled.